### PR TITLE
fix unix bug

### DIFF
--- a/loadcurry3.3.0/LoadCurryDataFile.m
+++ b/loadcurry3.3.0/LoadCurryDataFile.m
@@ -85,7 +85,11 @@ end
 [pathName,fileName,extension] = fileparts(dataFile);
 
 if ( strcmpi ( extension,'.dat' ) )
-    baseName = [pathName,'\',fileName];
+    if ispc
+        baseName = [pathName,'\',fileName];
+    else
+        baseName = [pathName,'/',fileName];
+    end
     parameterFile = [baseName,'.dap'];
     labelFile = [baseName,'.rs3'];
     eventFile = [baseName,'.cef'];

--- a/loadcurry3.3.0/loadcurry.m
+++ b/loadcurry3.3.0/loadcurry.m
@@ -406,6 +406,7 @@ function [EEG, command] = loadcurry(fullfilename, varargin)
                 % Add events
                 EEG.event = struct('type', [], 'latency', [], 'urevent', []);
                 EEG.urevent = struct('type', [], 'latency', []);
+                EEG.annotations = annotations;
 
                 % Populate list based on values different from 0, triggers may last more than one sample
                 templat = find(data(trigindx,:) ~= 0);


### PR DESCRIPTION
This is a bugfix for issue #6. It checks whether it is running on a Windows machine - in which case it uses '\' in filepath concatenation - or a unix machine - in which case it uses '/'.

It also passes through event annotations to the EEGlab structure, which previously were read by LoadCurryDataFile but not used.